### PR TITLE
[12] gmscompat: Add ConnectivityManager hook for baseline compatibility

### DIFF
--- a/framework/src/android/net/ConnectivityManager.java
+++ b/framework/src/android/net/ConnectivityManager.java
@@ -36,6 +36,7 @@ import android.annotation.SystemApi;
 import android.annotation.SystemService;
 import android.app.PendingIntent;
 import android.app.admin.DevicePolicyManager;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.ComponentName;
 import android.content.Context;
@@ -2605,6 +2606,10 @@ public class ConnectivityManager {
     @RequiresPermission(anyOf = {android.Manifest.permission.TETHER_PRIVILEGED,
             android.Manifest.permission.WRITE_SETTINGS})
     public boolean isTetheringSupported() {
+        if (GmsCompat.isEnabled()) {
+            return false;
+        }
+
         return getTetheringManager().isTetheringSupported();
     }
 


### PR DESCRIPTION
This is part of GmsCompat's baseline compatibility for unprivileged
Google Play Services.

Change-Id: I3e87706f1f3b87c0af9d00f6ce92144469596f8c