### PR TITLE
bugfix: reportNetworkConnectivity() wasn't switched to isInternetCompatEnabled()

### DIFF
--- a/framework/src/android/net/ConnectivityManager.java
+++ b/framework/src/android/net/ConnectivityManager.java
@@ -25,7 +25,6 @@ import static android.net.NetworkRequest.Type.TRACK_DEFAULT;
 import static android.net.NetworkRequest.Type.TRACK_SYSTEM_DEFAULT;
 import static android.net.QosCallback.QosCallbackRegistrationException;
 
-import android.Manifest;
 import android.annotation.CallbackExecutor;
 import android.annotation.IntDef;
 import android.annotation.NonNull;
@@ -44,7 +43,7 @@ import android.compat.annotation.UnsupportedAppUsage;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
+import android.content.pm.SpecialRuntimePermAppUtils;
 import android.net.ConnectivityDiagnosticsManager.DataStallReport.DetectionMethod;
 import android.net.IpSecManager.UdpEncapsulationSocket;
 import android.net.SocketKeepalive.Callback;
@@ -3146,12 +3145,12 @@ public class ConnectivityManager {
      */
     public void reportNetworkConnectivity(@Nullable Network network, boolean hasConnectivity) {
         printStackTrace();
-        if (mContext.checkSelfPermission(Manifest.permission.INTERNET) != PackageManager.PERMISSION_GRANTED) {
-            // ConnectivityService enforces this by throwing an unexpected SecurityException,
-            // which puts GMS into a crash loop. Also useful for other apps that don't expect that
-            // INTERNET permission might get revoked.
+
+        if (SpecialRuntimePermAppUtils.isInternetCompatEnabled()) {
+            // caller doesn't have INTERNET, but expects to always have it
             return;
         }
+
         try {
             mService.reportNetworkConnectivity(network, hasConnectivity);
         } catch (RemoteException e) {


### PR DESCRIPTION
`checkSelfPermission(Manifest.permission.INTERNET)` result can be spoofed now, which breaks the previous check.

Depends on https://github.com/GrapheneOS/platform_frameworks_base/pull/229