### PR TITLE
Prevent using SO_BINDTODEVICE to bypass VPN leak protection

### DIFF
--- a/bpf_progs/netd.h
+++ b/bpf_progs/netd.h
@@ -156,8 +156,7 @@ ASSERT_STRING_EQUAL(XT_BPF_ALLOWLIST_PROG_PATH, BPF_NETD_PATH "prog_netd_skfilte
 ASSERT_STRING_EQUAL(XT_BPF_DENYLIST_PROG_PATH,  BPF_NETD_PATH "prog_netd_skfilter_denylist_xtbpf");
 
 #define CGROUP_SOCKET_PROG_PATH BPF_NETD_PATH "prog_netd_cgroupsock_inet_create"
-#define CGROUP_SETSOCKOPT_LOCKDOWN_VPN_MULTICAST_PROG_PATH BPF_NETD_PATH \
-    "prog_netd_setsockopt_lockdown_vpn_multicast"
+#define CGROUP_SETSOCKOPT_PROG_PATH BPF_NETD_PATH "prog_netd_setsockopt_prog"
 
 #define TC_BPF_INGRESS_ACCOUNT_PROG_NAME "prog_netd_schedact_ingress_account"
 #define TC_BPF_INGRESS_ACCOUNT_PROG_PATH BPF_NETD_PATH TC_BPF_INGRESS_ACCOUNT_PROG_NAME
@@ -194,7 +193,8 @@ enum UidOwnerMatchType : uint32_t {
     OEM_DENY_1_MATCH = (1 << 9),
     OEM_DENY_2_MATCH = (1 << 10),
     OEM_DENY_3_MATCH = (1 << 11),
-    BACKGROUND_MATCH = (1 << 12)
+    BACKGROUND_MATCH = (1 << 12),
+    LOCKDOWN_VPN_REGULAR_APP_MATCH = (1 << 30)
 };
 // LINT.ThenChange(../framework/src/android/net/BpfNetMapsConstants.java)
 

--- a/framework/src/android/net/BpfNetMapsConstants.java
+++ b/framework/src/android/net/BpfNetMapsConstants.java
@@ -79,6 +79,7 @@ public class BpfNetMapsConstants {
     public static final long OEM_DENY_2_MATCH = (1 << 10);
     public static final long OEM_DENY_3_MATCH = (1 << 11);
     public static final long BACKGROUND_MATCH = (1 << 12);
+    public static final long LOCKDOWN_VPN_REGULAR_APP_MATCH = (1 << 30);
 
     public static final List<Pair<Long, String>> MATCH_LIST = Arrays.asList(
             Pair.create(HAPPY_BOX_MATCH, "HAPPY_BOX_MATCH"),
@@ -93,7 +94,8 @@ public class BpfNetMapsConstants {
             Pair.create(OEM_DENY_1_MATCH, "OEM_DENY_1_MATCH"),
             Pair.create(OEM_DENY_2_MATCH, "OEM_DENY_2_MATCH"),
             Pair.create(OEM_DENY_3_MATCH, "OEM_DENY_3_MATCH"),
-            Pair.create(BACKGROUND_MATCH, "BACKGROUND_MATCH")
+            Pair.create(BACKGROUND_MATCH, "BACKGROUND_MATCH"),
+            Pair.create(LOCKDOWN_VPN_REGULAR_APP_MATCH, "LOCKDOWN_VPN_REGULAR_APP_MATCH")
     );
 
     /**

--- a/netd/BpfHandler.cpp
+++ b/netd/BpfHandler.cpp
@@ -160,8 +160,7 @@ static Status initPrograms(const char* cg2_path) {
     // in 5.8, which our program requires.
     if (bpf::isAtLeastKernelVersion(5, 8, 0)) {
         RETURN_IF_NOT_OK(
-                attachProgramToCgroup(CGROUP_SETSOCKOPT_LOCKDOWN_VPN_MULTICAST_PROG_PATH, cg_fd,
-                                      BPF_CGROUP_SETSOCKOPT));
+                attachProgramToCgroup(CGROUP_SETSOCKOPT_PROG_PATH, cg_fd, BPF_CGROUP_SETSOCKOPT));
         if (bpf::queryProgram(cg_fd, BPF_CGROUP_SETSOCKOPT) <= 0) abort();
     }
 

--- a/service/src/com/android/server/BpfNetMaps.java
+++ b/service/src/com/android/server/BpfNetMaps.java
@@ -27,6 +27,7 @@ import static android.net.BpfNetMapsConstants.HAPPY_BOX_MATCH;
 import static android.net.BpfNetMapsConstants.IIF_MATCH;
 import static android.net.BpfNetMapsConstants.INGRESS_DISCARD_MAP_PATH;
 import static android.net.BpfNetMapsConstants.LOCKDOWN_VPN_MATCH;
+import static android.net.BpfNetMapsConstants.LOCKDOWN_VPN_REGULAR_APP_MATCH;
 import static android.net.BpfNetMapsConstants.PENALTY_BOX_MATCH;
 import static android.net.BpfNetMapsConstants.UID_OWNER_MAP_PATH;
 import static android.net.BpfNetMapsConstants.UID_PERMISSION_MAP_PATH;
@@ -49,6 +50,7 @@ import static com.android.server.ConnectivityStatsLog.NETWORK_BPF_MAP_INFO;
 
 import android.app.StatsManager;
 import android.content.Context;
+import android.ext.ConnectivityUtil;
 import android.net.BpfNetMapsReader;
 import android.net.INetd;
 import android.net.UidOwnerValue;
@@ -133,6 +135,7 @@ public class BpfNetMaps {
             Pair.create(PERMISSION_INTERNET, "PERMISSION_INTERNET"),
             Pair.create(PERMISSION_UPDATE_DEVICE_STATS, "PERMISSION_UPDATE_DEVICE_STATS")
     );
+    private Context mContext;
 
     /**
      * Set configurationMap for test.
@@ -370,6 +373,7 @@ public class BpfNetMaps {
         }
         mNetd = netd;
         mDeps = deps;
+        mContext = context;
     }
 
     private void maybeThrow(final int err, final String msg) {
@@ -786,8 +790,12 @@ public class BpfNetMaps {
 
         if (add) {
             addRule(uid, LOCKDOWN_VPN_MATCH, "updateUidLockdownRule");
+            if (!ConnectivityUtil.isSystem(mContext, uid)) {
+                addRule(uid, LOCKDOWN_VPN_REGULAR_APP_MATCH, "updateUidLockdownRule");
+            }
         } else {
             removeRule(uid, LOCKDOWN_VPN_MATCH, "updateUidLockdownRule");
+            removeRule(uid, LOCKDOWN_VPN_REGULAR_APP_MATCH, "updateUidLockdownRule");
         }
     }
 


### PR DESCRIPTION
SO_BINDTODEVICE can be used to bypass the VPN leak protection as it is implemented using routing.

This was discovered during my investigation of the multicast leaks, however I was unaware that this socket option was now available to unprivileged users.

Resolves https://github.com/GrapheneOS/os-issue-tracker/issues/2381