### PR TITLE
disable CLOSE_QUIC_CONNECTION power optimization that bypasses VPN

### DIFF
--- a/service/src/com/android/server/ConnectivityService.java
+++ b/service/src/com/android/server/ConnectivityService.java
@@ -1170,7 +1170,7 @@ public class ConnectivityService extends IConnectivityManager.Stub
     private final boolean mIngressToVpnAddressFiltering;
 
     // Flag to close QUIC connection for registered sockets when apps lose network access.
-    private final boolean mCloseQuicConnection;
+    private final boolean mCloseQuicConnection = false;
 
     // This is null if mCloseQuicConnection is false
     @Nullable
@@ -2392,10 +2392,6 @@ public class ConnectivityService extends IConnectivityManager.Stub
 
         mL2capNetworkProvider = mDeps.makeL2capNetworkProvider(mContext);
 
-        // QUIC connection close is triggered by freezer (U+) or background firewall chain (V+).
-        // TODO: Allow other firewall chains to close QUIC connection and enable this flag on T+
-        mCloseQuicConnection = mDeps.isAtLeastU()
-                && mDeps.isFeatureNotChickenedOut(context, CLOSE_QUIC_CONNECTION);
         if (mCloseQuicConnection) {
             mQuicConnectionCloser = mDeps.makeQuicConnectionCloser(mNetworkForNetId, mHandler);
         } else {


### PR DESCRIPTION
See
https://lowlevel.fun/posts/tiny-udp-cannon-android-vpn-bypass/
https://github.com/GrapheneOS/platform_packages_modules_Connectivity/commit/627b8c6d343e2a38869cdbff9c1d09a15716b47a 
https://chromium-review.googlesource.com/c/chromium/src/+/6421621

The usage of this optimizaton is still disabled as of May 2026 by the
kQuicRegisterConnectionClosePayload flag in Chromium and in AOSP cronet.