### PR TITLE
gmscompat: add stub for NsdManager.registerService()

### DIFF
--- a/framework-t/src/android/net/nsd/NsdManager.java
+++ b/framework-t/src/android/net/nsd/NsdManager.java
@@ -1976,6 +1976,9 @@ public final class NsdManager {
             mService.registerService(key, advertisingRequest);
         } catch (RemoteException e) {
             e.rethrowFromSystemServer();
+        } catch (SecurityException e) {
+            android.app.compat.gms.GmsCompat.catchOrRethrow(e);
+            new NsdCallbackImpl(mHandler).onRegisterServiceFailed(key, FAILURE_PERMISSION_DENIED);
         }
     }
 


### PR DESCRIPTION
NsdManager.registerService() is now protected by the ACCESS_LOCAL_NETWORK permission.